### PR TITLE
Fixed CORS violation errors on backend

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,6 +3,7 @@ let path = require('path');
 let logger = require('morgan');
 let cookieParser = require('cookie-parser');
 let bodyParser = require('body-parser');
+const cors = require('cors');
 
 let index = require('./routes/index');
 let users = require('./routes/users');
@@ -24,6 +25,10 @@ if (JWT_SECRET === undefined || JWT_SECRET === '') {
 
 // uncomment after placing your favicon in /public
 // app.use(favicon(path.join(__dirname, 'public', 'favicon.ico')));
+
+// CORS for all routes
+app.use(cors());
+
 app.use(logger('dev'));
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({extended: false}));

--- a/routes/docker.js
+++ b/routes/docker.js
@@ -2,10 +2,8 @@ const express = require('express');
 const request = require('request');
 const router = new express.Router();
 
-const cors = require('cors');
-
 /* Proxy for docker socket */
-router.all('*', cors(), function(req, res, next) {
+router.all('*', function(req, res, next) {
     const requestOptions = {
         baseUrl: 'http://unix:/var/run/docker.sock:',
         url: req.url,


### PR DESCRIPTION
For some reason, the CORS middleware was not correctly inserted for some routes. @CDuPlooy noticed this on the fronted when he tried to access `http://localhost:8080/docker/networks`:

![image](https://user-images.githubusercontent.com/5329962/39908511-b1e8ad62-54ee-11e8-97cc-57f188ee3d91.png)

This pull request moves the CORS middleware outside the `docker/` endpoint to the global routes.

