### PR TITLE
Integration Testing and API specification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,14 @@
+dist: trusty
+
+sudo: required
+
+services:
+  - docker
+
 language: node_js
+
 node_js:
    - node
-dist: trusty
 
 cache:
     npm: true
@@ -13,6 +20,7 @@ before_script:
 
 script:
    - npm test
+   - ./integration-test.sh
 
 notifications:
     on_failure: change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Changed
+- Check credentials in database instead of only checking `admin/admin` when requesting a JWT
+
+## [0.0.2] - 2018-05-11
+- Demo 2 release
+
+## 0.0.1 - 2018-04-14
+- Demo 1 release
+
+[Unreleased]: https://github.com/TripleParity/docks-api/compare/0.0.2...HEAD
+[0.0.2]: https://github.com/TripleParity/docks-api/compare/0.0.1...0.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- Integration testing
+- Integration testing using [frisby] and [jest] ([#41])
+- API Specification for Docks following [API Blueprint] ([#41])
 
 ### Changed
-- Check credentials in database instead of only checking `admin/admin` when requesting a JWT
+- Check credentials in database instead of only checking `admin/admin` when requesting a JWT ([#29])
 
 ### Fixed
 - Wait for database before starting Docks
@@ -22,3 +23,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 [Unreleased]: https://github.com/TripleParity/docks-api/compare/0.0.2...HEAD
 [0.0.2]: https://github.com/TripleParity/docks-api/compare/0.0.1...0.0.2
+
+[#41]: https://github.com/TripleParity/docks-api/issues/41
+[#29]: https://github.com/TripleParity/docks-api/issues/29
+
+[frisby]: https://www.frisbyjs.com/
+[jest]: https://facebook.github.io/jest/
+[API Blueprint]: https://apiblueprint.org/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Integration testing
+
 ### Changed
 - Check credentials in database instead of only checking `admin/admin` when requesting a JWT
+
+### Fixed
+- Wait for database before starting Docks
 
 ## [0.0.2] - 2018-05-11
 - Demo 2 release

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:9.8.0-alpine
 
 MAINTAINER TripleParity
 
-RUN apk add --update python make g++
+RUN apk add --update python make g++ postgresql-client
 
 EXPOSE 8080
 
@@ -13,4 +13,4 @@ RUN npm install --only=production
 
 COPY . .
 
-CMD ./scripts/docks-prod-start.sh
+CMD ["/app/scripts/docks-prod-start.sh"]

--- a/__tests__/api/api_spec.js
+++ b/__tests__/api/api_spec.js
@@ -1,0 +1,54 @@
+const frisby = require('frisby');
+const Joi = frisby.Joi; // Frisby exports Joi for convenience on type assersions
+
+const host = 'http://127.0.0.1:8080';
+
+describe('Authentication', function() {
+
+    it('should not serve Docker API requests without a JWT', function () {
+        return frisby.get(host + '/docker/containers/json')
+            .expect('status', 401);
+    });
+
+    it('should serve JWT for valid ("admin/admin") credentials', function() {
+        return frisby
+            .post(host + '/api/auth/token', {
+                username: 'admins',
+                password: 'admin',
+            })
+            .expect('status', 200)
+            .expect('bodyContains', 'jwt')
+            .expect('jsonTypes', 'jwt', Joi.string().required())
+            .then(function(res) {
+               let jwt = res.json['jwt'];
+
+               return frisby.fetch(host + '/', {
+                   method: 'GET',
+                   headers: {
+                       Authorization: 'Bearer ' + jwt,
+                   },
+               }).expect('status', 200)
+                   .expect('bodyContains', 'Welcome to Express');
+            });
+    });
+
+    it('should not serve JWT for invalid username', function() {
+        return frisby
+            .post(host + '/api/auth/token', {
+                username: 'h4z0r',
+                password: 'admin',
+            })
+            .expect('status', 401)
+            .expectNot('bodyContains', 'jwt');
+    });
+
+    it('should not serve JWT for invalid password', function() {
+        return frisby
+            .post(host + '/api/auth/token', {
+                username: 'admin',
+                password: 'h4x0r',
+            })
+            .expect('status', 401)
+            .expectNot('bodyContains', 'jwt');
+    });
+});

--- a/__tests__/api/api_spec.js
+++ b/__tests__/api/api_spec.js
@@ -13,7 +13,7 @@ describe('Authentication', function() {
     it('should serve JWT for valid ("admin/admin") credentials', function() {
         return frisby
             .post(host + '/api/auth/token', {
-                username: 'admins',
+                username: 'admin',
                 password: 'admin',
             })
             .expect('status', 200)

--- a/app.js
+++ b/app.js
@@ -11,7 +11,15 @@ let dockerProxyRouter = require('./routes/docker');
 let auth = require('./routes/auth');
 let jwtMiddleware = require('./jwt');
 
+const db = require('./db');
+
+const UserManager = require('./lib/user_manager');
+
 let app = express();
+
+let userManager = new UserManager(db);
+initDatabase(); // block
+userManager.createUser('Fred', 'pop');
 
 // view engine setup
 app.set('views', path.join(__dirname, 'views'));
@@ -60,5 +68,10 @@ app.use(function(err, req, res, next) {
     res.status(err.status || 500);
     res.render('error');
 });
+
+async function initDatabase() {
+    console.log("Initializing database...");
+    await userManager.initDatabase();
+}
 
 module.exports = app;

--- a/db.js
+++ b/db.js
@@ -1,0 +1,21 @@
+const DOCKS_DB_ADDRESS = process.env['DOCKS_DB_ADDRESS'];
+if (DOCKS_DB_ADDRESS === undefined || DOCKS_DB_ADDRESS === '') {
+    console.warn('Warning: Docks database address not set! Change DOCKS_DB_ADDRESS to the database address');
+}
+
+const Sequelize = require('sequelize');
+
+const db = new Sequelize('postgres', 'postgres', 'example', {
+    host: DOCKS_DB_ADDRESS,
+    dialect: 'postgres',
+    operatorsAliases: false,
+
+    pool: {
+        max: 5,
+        min: 0,
+        acquire: 30000,
+        idle: 10000,
+    },
+});
+
+module.exports = db;

--- a/db.js
+++ b/db.js
@@ -3,9 +3,14 @@ if (DOCKS_DB_ADDRESS === undefined || DOCKS_DB_ADDRESS === '') {
     console.warn('Warning: Docks database address not set! Change DOCKS_DB_ADDRESS to the database address');
 }
 
+const POSTGRES_PASSWORD = process.env['POSTGRES_PASSWORD'];
+if (POSTGRES_PASSWORD === undefined || POSTGRES_PASSWORD === '') {
+    console.warn('Warning: Docks database password not set! Change POSTGRES_PASSWORD to the database password for user postgresql');
+}
+
 const Sequelize = require('sequelize');
 
-const db = new Sequelize('postgres', 'postgres', 'example', {
+const db = new Sequelize('postgres', 'postgres', POSTGRES_PASSWORD, {
     host: DOCKS_DB_ADDRESS,
     dialect: 'postgres',
     operatorsAliases: false,

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,9 @@
+version: '3.2'
+
+services:
+
+  api:
+    image: docks-api:local
+    build:
+      context: .
+      dockerfile: Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,27 +3,19 @@ version: '3.2'
 services:
 
   api:
-    build:
-      context: .
-      dockerfile: Dockerfile-dev
+    image: tripleparity/docks-api
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - type: bind
-        source: ./
-        target: /app
     environment:
       - JWT_SECRET=changeme
+      - DOCKS_DB_ADDRESS=db
+      - POSTGRES_PASSWORD=example
     ports:
       - 8080:8080
+    depends_on:
+      - db
 
   db:
     image: postgres
     environment:
       POSTGRES_PASSWORD: example
-    ports:
-      - 5432:5432
-
-  adminer:
-    image: adminer
-    ports:
-      - 8082:8080

--- a/docks.apib
+++ b/docks.apib
@@ -1,0 +1,58 @@
+FORMAT: 1A
+HOST: http://127.0.0.1:8080
+
+# Docks
+
+Docks API
+
+# Group Authentication
+## Tokens [/api/auth/token]
+### Request new JWT [POST]
+
+Request a new JWT for use in Authenticated requests
+
++ Request (application/json)
+
+        {
+            "username": "admin",
+            "password": "admin"
+        }
+
++ Response 200 (application/json)
+    Valid credentials
+
+    + Body
+
+            {
+                "jwt": "8HhsbJ86AFjjhzj.ASKI9ghA7778ah.blahlbalhlb"
+            }
+
++ Response 401 (application/json)
+    Invalid credentials
+
+    + Body
+
+            {
+                "message": "Invalid username or password"
+            }
+
+# Group Docker
+## Containers [/docker]
+### List Containers [GET /docker/containers/json]
+
++ Request
+
+    + Headers
+
+            Authorization: Bearer <jwt>
+
++ Response 200 (application/json)
+    Valid credentials
+
+    + Body
+
+            See Docker API
+
++ Response 403 (application/json)
+
+    

--- a/integration-test.sh
+++ b/integration-test.sh
@@ -2,6 +2,8 @@
 
 sudo docker-compose -f docker-compose.yml -f docker-compose.local.yml up --force-recreate --build -d
 
+./wait-for-docks.sh "http://127.0.0.1:8080"
+
 npm run-script jest
 return=$?
 

--- a/integration-test.sh
+++ b/integration-test.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+sudo docker-compose -f docker-compose.yml -f docker-compose.local.yml up --force-recreate --build -d
+
+npm run-script jest
+return=$?
+
+sudo docker-compose down -v
+
+exit $return

--- a/lib/user_manager.js
+++ b/lib/user_manager.js
@@ -17,7 +17,7 @@ class UserManager {
         this.db = db;
         this.ready = false;
 
-        // TODO(egeldenhuys): Move do dedicated models file/dir?
+        // TODO(egeldenhuys): Move to dedicated models file/dir?
         this.User = this.db.define('User', {
             id: {
                 type: Sequelize.INTEGER,
@@ -32,6 +32,7 @@ class UserManager {
                 type: Sequelize.STRING,
             },
         });
+
     }
 
     /**
@@ -109,6 +110,8 @@ class UserManager {
                 } else {
                     resolve(false);
                 }
+            }).catch((err) => {
+                reject(err);
             });
         });
     }
@@ -135,7 +138,10 @@ class UserManager {
                 } else {
                     resolve(null);
                 }
-            });
+            })
+                .catch((err) => {
+                    reject(err);
+                });
         });
     }
 
@@ -160,7 +166,10 @@ class UserManager {
                 } else {
                     resolve(false);
                 }
-            });
+            })
+                .catch((err) => {
+                    reject(err);
+                });
         });
     }
 
@@ -183,7 +192,10 @@ class UserManager {
                } else {
                    resolve(false);
                }
-            });
+            })
+                .catch((err) => {
+                    reject(err);
+                });
         });
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docks",
-  "version": "0.0.0",
+  "version": "0.0.2",
   "private": true,
   "scripts": {
     "start": "nodemon ./bin/www",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "start": "nodemon ./bin/www",
     "production": "node ./bin/www",
-    "test": "jasmine"
+    "test": "jasmine",
+    "jest": "jest"
   },
   "dependencies": {
     "bcrypt": "^2.0.1",
@@ -27,7 +28,9 @@
   "devDependencies": {
     "eslint": "^4.19.1",
     "eslint-config-google": "^0.9.1",
+    "frisby": "^2.0.16",
     "jasmine": "^3.1.0",
+    "jest": "^23.1.0",
     "node-pre-gyp": "^0.10.0",
     "nodemon": "^1.17.2",
     "sqlite3": "^4.0.0"

--- a/scripts/docks-prod-start.sh
+++ b/scripts/docks-prod-start.sh
@@ -1,5 +1,13 @@
 #!/bin/sh
 
+set -e
+
+# Wait for postgresql to be functional
+until PGPASSWORD=$POSTGRES_PASSWORD psql -h "$DOCKS_DB_ADDRESS" -U "postgres" -c '\q'; do
+  >&2 echo "Postgres is unavailable - sleeping"
+  sleep 1
+done
+
 # Test if the Docker socket file exists
 if test -S "/var/run/docker.sock";
 then

--- a/spec/user_manager_spec.js
+++ b/spec/user_manager_spec.js
@@ -16,7 +16,7 @@ describe('The UserManager', function() {
         userManager = new UserManager(db);
         await userManager.initDatabase();
 
-    })
+    });
 
     it('has a connection to the test database', async function() {
         try {
@@ -34,7 +34,7 @@ describe('The UserManager', function() {
         expect(user).not.toBe(null);
         expect(user.id).toBe(1);
         expect(user.username).toBe('admin');
-    })
+    });
 
     it('can create new users with an auto incrementing id', async function() {
         let newUser = await userManager.createUser('Fred', 'pass');

--- a/wait-for-docks.sh
+++ b/wait-for-docks.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -e
+
+host=$1
+
+# Wait for postgresql to be functional
+until curl $host; do
+  >&2 echo "Docks is unavailable - sleeping"
+  sleep 1
+done
+
+echo "Docks is ready"


### PR DESCRIPTION
Requires #42 

Closes #41 

## Changelog
### Added
- Integration testing using [frisby](https://www.frisbyjs.com/) and [jest](https://facebook.github.io/jest/)
- API Specification for Docks following [API Blueprint](https://apiblueprint.org/)

### Fixed
- Wait for database before starting Docks

## API Spec
An example of the rendered Docks API spec can be viewed [here](https://tripleparity.github.io/docks-api/index.html), generated with [aglio](https://github.com/danielgtaylor/aglio). For now the pretty API page is not built automatically.

## Testing
```
git clone https://github.com/TripleParity/docks-api --branch api-testing-\#41
cd docks-api
npm install # this may take a while...
npm test # Unit tests
./integration-test.sh # Run integration test by building Docks-API and running using Docker
```

## Notes
@devosray , the development Docker files have not been modified since I do not use that workflow