### PR TITLE
Fix stack list endpoint

### DIFF
--- a/docker-compose/build-to-registry.sh
+++ b/docker-compose/build-to-registry.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Build Docks API image and push to local registry
+
+docker build -t 127.0.0.1:5000/docks-api:local ../
+docker push 127.0.0.1:5000/docks-api:local

--- a/routes/stacksApi.js
+++ b/routes/stacksApi.js
@@ -248,7 +248,7 @@ async function retrieveStackList() {
   // Skip first line (header)
   for (let i = 1; i < outputLines.length; i++) {
     const nameCountSplit = outputLines[i].match(/\S+/g) || [];
-    if (nameCountSplit.length !== 2) {
+    if (nameCountSplit.length !== 3) {
       continue;
     }
 


### PR DESCRIPTION
Closes #69 

The new Docker CLI outputs 3 columns instead of 2