### PR TITLE
Increase Docker CLI timeout

### DIFF
--- a/routes/stacksApi.js
+++ b/routes/stacksApi.js
@@ -13,7 +13,7 @@ const execFileAsync = util.promisify(execFile);
 /* Api endpoint to build and run a docker-compose file */
 
 // Timeout in milliseconds for CLI calls to docker
-const DOCKER_CLI_TIMEOUT = 5000;
+const DOCKER_CLI_TIMEOUT = 15000;
 
 // Get all stacks running in the Swarm
 router.get('/', async (req, res, next) => {

--- a/routes/stacksApi.js
+++ b/routes/stacksApi.js
@@ -25,6 +25,8 @@ router.get('/', async (req, res, next) => {
 
 // Deploy a new stack to the Swarm. The stack name should not exist
 router.post('/', async function(req, res, next) {
+  req.setTimeout(DOCKER_CLI_TIMEOUT);
+
   if (!req.body.hasOwnProperty('stackName') || req.body['stackName'] === '') {
     res.status(400).send('Required parameter stackName missing');
     return;


### PR DESCRIPTION
Fixes #75 

### Changelog
#### Changed
- Set Docker CLI timout to 15 seconds to prevent Docker CLI being killed on slow systems
- Set POST `/stack` endpoint request timeout to 15 seconds to prevent HTTP timeouts when Docker is slow
