### PR TITLE
FIX CLI timeout visibility

### DIFF
--- a/lib/docker_api_helpers.js
+++ b/lib/docker_api_helpers.js
@@ -293,7 +293,9 @@ async function getServiceIDsByStack(stackName) {
   return splitList.filter((id) => id.length > 0);
 }
 
-module.exports = {doesStackExistInSwarm,
+module.exports = {
+  DOCKER_CLI_TIMEOUT,
+  doesStackExistInSwarm,
   retrieveStackList,
   getServicesByStack,
   inspectNetworkAxios,


### PR DESCRIPTION
I forgot to export the CLI timeout variable, making PR #84 unusable. This fixes it.